### PR TITLE
Avoid using ADD, instead go for COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN \
   yum clean all
 
 
-ADD run.sh /bin/run.sh
+COPY run.sh /bin/run.sh
 RUN chmod a+x /bin/run.sh
 COPY reload.sh  /bin/reload
 RUN chmod a+x /bin/reload


### PR DESCRIPTION
ADD is useful for auto-extraction on TARs, but if not needed, use COPY instead.